### PR TITLE
Add Google authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Authentication
+
+This project uses [NextAuth.js](https://next-auth.js.org/) for authentication.
+
+To enable Google sign-in, add the following environment variables to your `.env` file:
+
+```bash
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+```

--- a/src/app/components/sign-in-form.tsx
+++ b/src/app/components/sign-in-form.tsx
@@ -7,6 +7,7 @@ import { signIn } from "next-auth/react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
 import {
   Form,
   FormControl,
@@ -64,6 +65,19 @@ export function SignIn() {
             <Button type="submit">Sign in with Resend</Button>
           </form>
         </Form>
+        <div className="flex items-center my-4">
+          <Separator className="flex-1" />
+          <span className="px-2 text-xs text-muted-foreground">Or login with</span>
+          <Separator className="flex-1" />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full"
+          onClick={() => signIn("google")}
+        >
+          Sign in with Google
+        </Button>
       </CardContent>
     </Card>
   );

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import NextAuth from "next-auth";
 import Resend from "next-auth/providers/resend";
+import Google from "next-auth/providers/google";
 import { db } from "./app/db";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
@@ -9,6 +10,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [
     Resend({
       from: process.env.EMAIL_FROM,
+    }),
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
     }),
   ],
 });

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SeparatorProps = React.HTMLAttributes<HTMLDivElement>;
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("h-px w-full bg-border", className)}
+      {...props}
+    />
+  )
+);
+Separator.displayName = "Separator";
+
+export { Separator };


### PR DESCRIPTION
## Summary
- support Google OAuth in NextAuth
- add Google sign-in button
- document Google auth environment variables
- add a shadcn-style separator to sign-in form

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac5d08c8308329967acc71ee829491